### PR TITLE
Deep clone original component parameters

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -5,16 +5,17 @@ const _ = require('lodash')
  * to GOV.UK form inputs. Generates attributes based on where they are stored
  * in the session data object.
  *
- * @param {string} params - Component parameters
+ * @param {string} originalParams - Component parameters
  * @param {string} keyPath - Path to key (using dot/bracket notation)
  * @param {string} [componentName] - Name of component calling decorate
  * @returns {Object} Updated component parameters
  */
-exports.decorate = function (params, keyPath, componentName) {
+exports.decorate = function (originalParams, keyPath, componentName) {
   if (typeof keyPath === 'undefined') {
-    return params
+    return originalParams
   }
 
+  const params = _.cloneDeep(originalParams)
   keyPath = _.toPath(keyPath)
 
   const { data, errors } = this.ctx


### PR DESCRIPTION
A bit of defensive coding…

@edwardhorsford is using an earlier/similar version of the decorate function on his prototype, and reported the following:

> I accidentally made an array in nunjucks that was including items by reference rather than copying them. And `decorateAttributes` then mutated the originals.

> I think it needs to make a copy of `params` rather than writing to it directly. In some cases it can end up mutating some reference data in session-data-defaults

This change deeply copies the original params before mutating them and passing them back to the component.

@edwardhorsford – is this the change you were thinking? Also, is there a good test I can write to check that this fix is working as intended?